### PR TITLE
Database design

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,11 +11,13 @@
 |last_name_kana|string|null: false|
 |first_name_kana|string|null: false|
 |birthday_info|date|null: false|
-|introduction|text|null: false|
-|address_id|reference|null: false, foreign_key: true|
-|rate_id|reference|null: false, foreign_key: true|
+|icon|string|
+|introduction|text|
 |point|integer|null: false|
 |proceed|integer|null: false|
+|bought_items|reference|null: false, foreign_key: true|
+|selling_items|reference|null: false, foreign_key: true|
+|sold_items|reference|null: false, foreign_key: true|
 
 ### Association
 - has_many :items
@@ -24,8 +26,10 @@
 - has_many :todos
 - has_many :rates
 - has_many :trades
-- belongs_to :seller, class_name: "User"
-- belongs_to :buyer, class_name: "User"
+- has_many :item_comments
+- has_many :bought_items, foreign_key: "buyer_id", class_name: "Item"
+- has_many :selling_items, -> { where("buyer_id is NULL") }, foreign_key: "seller_id", class_name: "Item"
+- has_many :sold_items, -> { where("buyer_id is not NULL") }, foreign_key: "seller_id", class_name: "Item"
 ***
 
 ## addressesテーブル
@@ -37,7 +41,6 @@
 |street|string|null: false|
 |building|string|
 |phone_number|string|
-|user_id|reference|null: false, foreign_key: true|
 
 ### Association
 - belongs_to :user
@@ -70,12 +73,9 @@
 |name|string|null: false|
 |status|integer|null: false|
 |user_id|reference|null: false, foreign_key: true|
-|item_id|reference|null: false, foreign_key: true|
-|trade_id|reference|null: false, foreign_key: true|
 
 ### Association
 - belongs_to :user
-- belongs_to :item
 - belongs_to :trade
 ***
 
@@ -83,8 +83,8 @@
 |Column|Type|Options|
 |------|----|-------|
 |comment|string|null: false|
-|user_id|reference|null: false, foreign_key: true|
 |item_id|reference|null: false, foreign_key: true|
+|user_id|reference|null: false, foreign_key: true|
 
 ### Association
 - belongs_to :user
@@ -122,39 +122,27 @@
 |name|string|null: false, index: true|
 |description|string|null: false|
 |condition|string|null: false|
-|price|integer|null: false|
-|itemimage_id|reference|null: false, foreign_key: true|
-|category_id|reference|null: false, foreign_key: true|
-|brand_id|reference|null: true, foreign_key: true|
-|size_id|reference|null: true, foreign_key: true|
-|shipping_id|reference|null: true, foreign_key: true|
-|seller_id|reference|null: false, foreign_key: true|
-|buyer_id|reference|null: false, foreign_key: true|
-|rate_id|reference|null: false, foreign_key: true|
-
-### Association
-- belongs_to :user
-- has_many :item_comments
-- belongs_to :trade
-- belongs_to :rate
-- belongs_to :shipping
-- has_many :item_images
-- has_many :categories
-- belongs_to :size
-- belongs_to :brand
-***
-
-## shippingsテーブル
-|Column|Type|Options|
-|------|----|-------|
 |shipping_method|string|null: false|
 |shipping_charge|string|null: false|
 |ship_from_region|string|null: false|
 |shipping_date|string|null: false|
-|item_id|reference|null: false, foreign_key: true|
+|price|integer|null: false|
+|seller_id|reference|null: false, foreign_key: true|
+|buyer_id|reference|null: false, foreign_key: true|
+|size_id|reference|null: true, foreign_key: true|
+|brand_id|reference|null: true, foreign_key: true|
 
 ### Association
-- belongs_to :item
+- belongs_to :user
+- has_many :item_images
+- has_many :item_categories
+- has_many :categories, through: :item_categories
+- has_many :item_comments
+- belongs_to :trade
+- belongs_to :size
+- belongs_to :brand
+- belongs_to :seller, class_name: "User"
+- belongs_to :buyer, class_name: "User"
 ***
 
 ## itemimagesテーブル
@@ -170,32 +158,37 @@
 ## categoriesテーブル
 |Column|Type|Options|
 |------|----|-------|
+|parent_id|integer|
 |name|string|null: false, unique: true|
-|ancestry|string|null: false, unique: true|
+
+### Association
+- has_many :item_categories
+- has_many :items, through: :item_categories
+***
+
+## item_categoriesテーブル
 |item_id|reference|null: false, foreign_key: true|
+|category_id|reference|null: false, foreign_key: true|
 
 ### Association
 - belongs_to :item
+- belongs_to :category
 ***
 
 ## brandsテーブル
 |Column|Type|Options|
 |------|----|-------|
 |name|string|null: false, unique: true, index: true|
-|category_id|reference|null: false, foreign_key: true|
-|item_id|reference|null: false, foreign_key: true|
 
 ### Association
-- belongs_to :item
+- has_many :items
 ***
 
 ## sizesテーブル
 |Column|Type|Options|
 |------|----|-------|
 |name|string|null: false, unique: true|
-|category_id|reference|null: false, foreign_key: true|
-|item_id|reference|null: false, foreign_key: true|
 
 ### Association
-- belongs_to :item
+- has_many :items
 ***


### PR DESCRIPTION
# WHAT
### usersテーブル
- ユーザーのプロフィール画像や説明文を表すicon、introductionカラムを追加
- ユーザー自身の出品および取引状況を表すbought_items、selling_items、sold_itemsカラムを追加
- アソシエーション表記ミスを削除（seller_idやbuyer_idはitemsテーブルに記述すべき）
- アソシエーションでbought_items、selling_items、sold_itemsカラムをItemクラスのbuyer_id、seller_idと紐付け
- selling_itemsに条件付きアソシエーションを設定（buyer_idがNULLの場合に出品中とする）
- sold_itemsに条件付きアソシエーションを設定（buyer_idがNULLでない場合に売却済とする）

### addressesテーブル
- user_idが不要のため削除

### ratesテーブル
- 不要な外部キー（item_id、trade_id）の削除
- 不要なアソシエーションの削除（tradesテーブルにitem_idが存在するため）

### itemsテーブル
- shippingsテーブルのカラムをitemsテーブルにまとめて追加（独立して保存する必要がないため）
- アソシエーションに伴う不要な外部キー（itemimage_id、category_id、shipping_id、rate_id）の削除
- 中間テーブル（item_caterogiesテーブル）用のアソシエーション記述
- アソシエーションの追記（Userクラスに紐付くseller_idやbuyer_idの記述）

### categoriesテーブル
- 経路列挙型から隣接リスト型に変更
- 変更に伴い、parent_idカラムを追加
- 中間テーブル（item_caterogiesテーブル）用のアソシエーション記述

### item_categoriesテーブル
- 中間テーブルの追加
- itemsテーブル、categoriesテーブルとのアソシエーション記述

### brandsテーブル
- アソシエーションの変更（belongs_to→has_many）
- アソシエーションに伴う不要な外部キーの削除

### sizesテーブル
- アソシエーションの変更（belongs_to→has_many）
- アソシエーションに伴う不要な外部キーの削除

#### 参考）ER図
https://cacoo.com/diagrams/zmmYJsRRnoA9lctY/02D09

# WHY
- DB設計に不足が見つかったため、前回のレビュー時から大幅に修正を加えました
- ユーザープロフィール画像、説明文の追加のため
- ユーザーの取引状況を出品停止を含めて再現するため
- 多階層カテゴリーの欠陥を防ぐため