### PR TITLE
Fix: protect_from_forgeryの記述が削除されていたため再記述

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,9 +1,9 @@
 class ApplicationController < ActionController::Base
+  protect_from_forgery with: :exception
   before_action :basic_auth, if: :production?
   before_action :configure_permitted_parameters, if: :devise_controller?
 
   protected
-
   def configure_permitted_parameters
     devise_parameter_sanitizer.permit(:sign_up, keys: [:nickname, :last_name, :first_name, :last_name_kana, :first_name_kana, :birthday_info])
   end


### PR DESCRIPTION
# WHAT
- protect_from_forgeryの再記述

# WHY
#### CSRF対策
- ログイン認証時に吐き出されるエラーの解消のため