### PR TITLE
商品一覧画面のh3タグのビュー崩れ解消および改善

### DIFF
--- a/app/assets/stylesheets/items.scss
+++ b/app/assets/stylesheets/items.scss
@@ -234,20 +234,23 @@ body{
 						background-color: #fff;
 						text-align: left;
 						position: relative;
-						&_item-name{
-							position: relative;
-							white-space: pre-line;
+						& h3{
+							word-break: break-word;
+							vertical-align: text-top;
 							overflow: hidden;
-							height: 48px;
-							& h3{
-								word-break: break-word;
-								vertical-align: text-top;
-								font-size: 16px;
-								line-height: 1.5;
-								font-weight: 400;
-								position: absolute;
-								top: 0;
-							}
+							font-size: 16px;
+							line-height: 1.2;
+							color: $black;
+							&::after{
+								display: block;
+						    content: '';
+						    position: absolute;
+						    top: 32px;
+						    right: 0;
+						    width: 50%;
+						    height: 1.5em;
+						    background: linear-gradient(to right, rgba(255,255,255,0), #fff 72%);
+						  }
 						}
 						&_item-box{
 							position: absolute;

--- a/app/assets/stylesheets/user.scss
+++ b/app/assets/stylesheets/user.scss
@@ -9,16 +9,6 @@ a {
   opacity: 0.7;
   }
 }
-
-h3 {
-  display: block;
-  font-size: 1.17em;
-  margin-block-start: 1em;
-  margin-block-end: 1em;
-  margin-inline-start: 0px;
-  margin-inline-end: 0px;
-  font-weight: bold;
-}
 .btn-default {
   display: block;
   width: 100%;
@@ -117,6 +107,7 @@ h3 {
     width: 100%;
     background-color: $white;
     font-size: 0;
+    font-weight: 600;
     & a {
       position: relative;
       display: block;
@@ -276,6 +267,7 @@ h3 {
     &__head {
       margin: 40px 0 0;
       font-size: 1rem;
+      font-weight: 600;
     }
     &__list {
       background-color: $white;


### PR DESCRIPTION
# WHAT
- h3に指定していたスタイルが干渉する問題を解消
- 商品名が要素をoverflowする際にグラデーションに見えるように擬似要素afterを追加し、スタイル適用

# WHY
- ユーザーの視覚体験向上のため