### PR TITLE
実装済みのビューにパーシャル化したヘッダー/フッターの呼び出し追記

### DIFF
--- a/app/controllers/users/sessions_controller.rb
+++ b/app/controllers/users/sessions_controller.rb
@@ -2,7 +2,6 @@
 
 class Users::SessionsController < Devise::SessionsController
   # before_action :configure_sign_in_params, only: [:create]
-  layout "users"
   # GET /resource/sign_in
   # def new
   #   super

--- a/app/views/items/show.html.haml
+++ b/app/views/items/show.html.haml
@@ -1,3 +1,5 @@
+= render partial: "layouts/main-header"
+
 / 全体
 %main.items-wrapper
   %section.item-detail-container
@@ -289,3 +291,5 @@
                     7
                 %p.item-other__user-items__content__box__num__tax
                   (税込)
+
+= render partial: "layouts/main-footer"

--- a/app/views/users/destroy.html.haml
+++ b/app/views/users/destroy.html.haml
@@ -1,3 +1,5 @@
+= render partial: "layouts/main-header"
+
 %main.mypage-container
   .mypage-content
     / ログアウト
@@ -104,3 +106,5 @@
           = link_to user_path, class: "mypage-side-nav__list__item" do
             ログアウト
             = icon "fas", "angle-right" , class: "mypage-side-nav__list__icon"
+
+= render partial: "layouts/main-footer"

--- a/app/views/users/edit.html.haml
+++ b/app/views/users/edit.html.haml
@@ -1,3 +1,5 @@
+= render partial: "layouts/main-header"
+
 %main.mypage-container
   .mypage-content
     / プロフィール編集
@@ -110,3 +112,5 @@
           = link_to "/users/#{current_user.id}", method: :delete, action: "destroy", class: "mypage-side-nav__list__item" do
             ログアウト
             = icon "fas", "angle-right" , class: "mypage-side-nav__list__icon"
+
+= render partial: "layouts/main-footer"

--- a/app/views/users/show.html.haml
+++ b/app/views/users/show.html.haml
@@ -1,3 +1,5 @@
+= render partial: "layouts/main-header"
+
 %main.mypage-container
   .mypage-content
     %section.mypage-user-icon
@@ -196,3 +198,5 @@
           = link_to "/users/#{current_user.id}", method: :delete, action: "destroy", class: "mypage-side-nav__list__item" do
             ログアウト
             = icon "fas", "angle-right" , class: "mypage-side-nav__list__icon"
+
+= render partial: "layouts/main-footer"


### PR DESCRIPTION
# WHAT
- パーシャル化したヘッダー/フッターを各ビューファイルに呼び出し追記

# WHY
- メイン画面や出品画面などでユーザーに異なる視覚体験を得てもらうため
- 画面によってヘッダー/フッターを使い分けるため
- 保守性の向上