### PR TITLE
商品出品機能のテスト

### DIFF
--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -23,10 +23,11 @@ end
 
 class Item < ApplicationRecord
   extend ActiveHash::Associations::ActiveRecordExtensions
-  validates :name, presence: true
-  validates :description, presence: true
+  validates :name, presence: true, length: { maximum: 40 }
+  validates :description, presence: true, length: { maximum: 1000 }
   validates :condition, presence: true
   validates :shipping_charge, presence: true
+  validates :shipping_method, presence: true
   validates :ship_from_region, presence: true
   validates :shipping_date, presence: true
   validates :price, presence: true

--- a/spec/controllers/items_controller_spec.rb
+++ b/spec/controllers/items_controller_spec.rb
@@ -60,4 +60,3 @@ describe ItemsController, type: :controller do
     end
   end
 end
-

--- a/spec/models/item_spec.rb
+++ b/spec/models/item_spec.rb
@@ -6,4 +6,82 @@ describe Item do
       item = build(:item)
     end
   end
+
+  describe '#create' do
+    it "is valid with a nickname, email, password, password_confirmation, last_name, first_name, last_name_kana, first_name_kana, birthday_info" do
+      item = build(:item)
+      expect(item).to be_valid
+    end
+
+    it "is invalid without a name" do
+      item = build(:item, name: nil)
+      item.valid?
+      expect(item.errors[:name]).to include("can't be blank")
+    end
+
+    it "is invalid without a description" do
+      item = build(:item, description: nil)
+      item.valid?
+      expect(item.errors[:description]).to include("can't be blank")
+    end
+
+    it "is invalid without a condition" do
+      item = build(:item, condition: nil)
+      item.valid?
+      expect(item.errors[:condition]).to include("can't be blank")
+    end
+
+    it "is invalid without a shipping_method" do
+      item = build(:item, shipping_method: nil)
+      item.valid?
+      expect(item.errors[:shipping_method]).to include("can't be blank")
+    end
+
+    it "is invalid without a shipping_charge" do
+      item = build(:item, shipping_charge: nil)
+      item.valid?
+      expect(item.errors[:shipping_charge]).to include("can't be blank")
+    end
+
+    it "is invalid without a ship_from_region" do
+      item = build(:item, ship_from_region: nil)
+      item.valid?
+      expect(item.errors[:ship_from_region]).to include("can't be blank")
+    end
+
+    it "is invalid without a shipping_date" do
+      item = build(:item, shipping_date: nil)
+      item.valid?
+      expect(item.errors[:shipping_date]).to include("can't be blank")
+    end
+
+    it "is invalid without a price" do
+      item = build(:item, price: nil)
+      item.valid?
+      expect(item.errors[:price]).to include("can't be blank")
+    end
+
+    it "is invalid name charactors more than 40" do
+      item = build(:item, name: "a"*41)
+      item.valid?
+      expect(item.errors[:name][0]).to include("is too long")
+    end
+
+    it "is invalid name charactors less than 40" do
+      item = build(:item, name: "a"*40)
+      expect(item).to be_valid
+    end
+
+    it "is invalid description charactors more than 1000" do
+      item = build(:item, description: "a"*1001)
+      item.valid?
+      expect(item.errors[:description][0]).to include("is too long")
+    end
+
+    it "is invalid description charactors less than 1000" do
+      item = build(:item, description: "a"*1000)
+      expect(item).to be_valid
+    end
+
+  end
 end

--- a/spec/models/itemimage_spec.rb
+++ b/spec/models/itemimage_spec.rb
@@ -1,5 +1,11 @@
 require 'rails_helper'
 
 RSpec.describe Itemimage, type: :model do
-  pending "add some examples to (or delete) #{__FILE__}"
+	describe Itemimage do
+	  it "画像が保存できていないとバリデーションで弾かれる" do
+	    itemimage = build(:itemimage, image: nil)
+	    itemimage.valid?
+	    expect(itemimage.errors[:image]).to include("can't be blank")
+	  end
+	end
 end

--- a/spec/models/itemimage_spec.rb
+++ b/spec/models/itemimage_spec.rb
@@ -2,10 +2,10 @@ require 'rails_helper'
 
 RSpec.describe Itemimage, type: :model do
 	describe Itemimage do
-	  it "画像が保存できていないとバリデーションで弾かれる" do
-	    itemimage = build(:itemimage, image: nil)
-	    itemimage.valid?
-	    expect(itemimage.errors[:image]).to include("can't be blank")
-	  end
-	end
+　　it "画像が保存できていないとバリデーションで弾かれる" do
+　　　itemimage = build(:itemimage, image: nil)
+　　　itemimage.valid?
+　　　expect(itemimage.errors[:image]).to include("can't be blank")
+　　end
+　end
 end


### PR DESCRIPTION
# WHAT
〜見ていただきたいファイル〜
spec/models/item_spec.rb 
spec/models/itemimage_spec.rb
spec/controllers/item_controller_spec.rb
factories/items.rb

### 商品出品に関するテストの実装
**itemモデルのテスト**
・全部記述していれば保存できているか
・商品名(name) 
・説明(description
・状態(condition)
・方法(shipping_method)
・負担(shipping_charge)
・日数(shipping_date)
・地域(ship_region)
・価格(price)
・商品名が４１字以上だと保存されないか
・商品名が４０字以内だと保存されるか
・商品の説明が１０００字以上だと保存されないか
・商品の説明が１０００字以内だと保存されるか
**itemimageモデルのテスト**
・画像
**itemコントローラーのテスト**
・フォームに必要な記述を全て書いたら保存ができているか
・保存した後トップページにリダイレクトされるか
＊現状updateアクションの部分のテストでエラーが出るようになっていますが、別のチームメンバーの方が対応中です。

# WHY
・フォームの「必須」と書かれた部分に空白があると商品が保存されないことを確認するため
・商品の名前（４０字以内）、説明（1000字以内）が指定の文字数を満たさなかった時に保存されないことを確認するため。