### PR TITLE
[WIP]ユーザーマイページの表示調整

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -1,4 +1,4 @@
- // *= require bxslider
+// *= require bxslider
 
 @import "./reset";
 @import "./variables";

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -4,6 +4,24 @@ class UsersController < ApplicationController
 
   def show
     @user = User.find(params[:id])
+    @items = Item.where('seller_id = ?', @user)
+  end
+
+  def edit
+    @user = User.find(params[:id])
+  end
+
+  def update
+    if current_user.update(user_profile_params)
+      redirect_to user_path
+    else
+      render :edit
+    end
+  end
+
+  private
+  def user_profile_params
+    params.require(:user).permit(:nickname, :introduction)
   end
 
 end

--- a/app/views/users/edit.html.haml
+++ b/app/views/users/edit.html.haml
@@ -6,11 +6,11 @@
     / プロフィール編集
     %section.mypage-content__setting-profile
       %h2.mypage-content__setting-profile__title プロフィール
-      = form_for "user", class: "mypage-content__setting-profile__form" do |f|
+      = form_for @user, class: "mypage-content__setting-profile__form" do |f|
         .mypage-content__setting-profile__form__icon
           %figure
             = image_tag "yu40ta-avatar.png", size: "60x60"
-          = f.text_field :nickname, class: "input-default", placeholder: "例）AYA☆セール中", value: ""
+          = f.text_field :nickname, class: "input-default", placeholder: "例）AYA☆セール中"
         .mypage-content__setting-profile__form__content
           = f.text_area :introduction, class: "textarea-default", placeholder: "例）こんにちは☆ ご覧いただきありがとうございます！かわいいものやきれいめオフィスカジュアル中心に出品しています。服のサイズは主に9号です。気持ちよくお取引できるよう心がけていますので、商品や発送方法などご質問がありましたらお気軽にどうぞ♪"
           %button.btn-default.btn-red{:type => "submit"} 変更する

--- a/app/views/users/show.html.haml
+++ b/app/views/users/show.html.haml
@@ -17,7 +17,7 @@
           .mypage-user-icon__number--display
             出品数
             %span.bold
-              0
+              = @items.length
     %section.mypage-content__tab-container-notification
       %ul.mypage-content__tabs
         %li.mypage-content__tabs--active

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -31,7 +31,7 @@ Rails.application.routes.draw do
     resources :trades
   end
   resource :address, except: [:destroy, :show]
-  resources :users # 後でonly: [:show, :index]など追記予定
+  resources :users, only: [:show, :edit, :destroy, :update]
 
   resources :users do
     resources :payments


### PR DESCRIPTION
# WHAT
- マイページ（一覧画面）に出品数を表示
- プロフィール編集/更新のため、edit/updateアクションの追加
- プロフィール編集画面にユーザーネームおよび紹介文を表示

# WHY
- ユーザーが自身の総出品数を確認できるようにするため
- ユーザーがプロフィールを適宜編集できるようにするため
